### PR TITLE
AdSense 審査向けに補助ページ4種・ads.txt・サイト情報フッターを追加

### DIFF
--- a/404.html
+++ b/404.html
@@ -95,6 +95,12 @@
                 <a href="/amida/">あみだくじ</a>
                 <a href="/filmfilter/">フィルム風フィルター</a>
             </div>
+            <div class="footer-links">
+                <a href="./about/index.html">このサイトについて</a>
+                <a href="./privacy/index.html">プライバシーポリシー</a>
+                <a href="./terms/index.html">利用規約</a>
+                <a href="./contact/index.html">お問い合わせ</a>
+            </div>
             <p>&copy; 2025 Kiricab. All Rights Reserved.</p>
         </div>
     </footer>

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,14 @@ python3 -m http.server 8000
 - `mdeditor/` — WYSIWYGマークダウンエディタ（現在開発中のブランチ：`mdeditor`）
 - `common/style.css` — 全ツール共通のCSSカスタムプロパティとベーススタイル
 
+**サイト全体の補助ページ**（ツールではないが必須。Google AdSense 審査の前提条件でもある）:
+
+- `about/` — このサイトについて（運営者・ミッション・収録ツール一覧）
+- `privacy/` — プライバシーポリシー（GA・AdSense のクッキー利用・オプトアウト案内を含む）
+- `terms/` — 利用規約（免責・禁止事項・準拠法）
+- `contact/` — お問い合わせ（GitHub Issues 一本化）
+- `ads.txt` — AdSense Authorized Sellers（`google.com, pub-8141179596557780, DIRECT, f08c47fec0942fa0`）
+
 ## アーキテクチャパターン
 
 **共通CSSカスタムプロパティ** — 全ツールが `../common/style.css` をインポートしてデザインシステム（`--primary-color: #1e3a8a` など）を参照し、ツール固有のスタイルは各 `style.css` に追記する。
@@ -55,7 +63,7 @@ python3 -m http.server 8000
 1. `index.html`・`script.js`・`style.css` を格納した新規ディレクトリを作成する
 2. `../common/style.css` をツール固有のスタイルシートより先にリンクする
 3. ファビコンは `<link rel="icon" href="../common/favicon.svg">` で共通ファイルを参照する
-4. 既存の全 `index.html` のフッターナビにリンクを追加する
+4. 既存の全 `index.html` のフッターナビにリンクを追加する（フッターは「ツール横断」と「サイト情報（about/privacy/terms/contact）」の 2 段構成。新ツールは前者に追加する）
 5. `sitemap.xml` を更新する（`lastmod` を当日日付、`changefreq` を `monthly` に設定）
 6. ルートの `index.html` にボタンを追加する
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,15 @@
 | [`colorpallet/`](./colorpallet/) | 配色ハーモニーモード・LocalStorage 保存・PNG/JSON エクスポート対応のカラーパレット生成 |
 | [`mdkanban/`](./mdkanban/) | Obsidian Kanban 互換 Markdown をカンバンボードとして表示・編集 |
 
+## サイト情報
+
+| ページ | 概要 |
+|---|---|
+| [`about/`](./about/) | このサイトについて（運営方針・収録ツール一覧） |
+| [`privacy/`](./privacy/) | プライバシーポリシー |
+| [`terms/`](./terms/) | 利用規約 |
+| [`contact/`](./contact/) | お問い合わせ（GitHub Issues） |
+
 ## ローカルでの動作確認
 
 ビルド手順・パッケージマネージャは不要。各ツールの `index.html` をブラウザで直接開けばよい。

--- a/about/index.html
+++ b/about/index.html
@@ -1,0 +1,225 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>このサイトについて | KIRICAB Tools</title>
+    <meta name="description" content="KIRICAB Toolsはインストール不要・登録不要・サーバー送信なしを徹底した日本語向け無料Webツール集。運営者・収録ツール・技術スタック・オープンソース方針について紹介します。">
+
+    <!-- OGP -->
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="https://kiricab.github.io/about/">
+    <meta property="og:title" content="このサイトについて | KIRICAB Tools">
+    <meta property="og:description" content="KIRICAB Toolsはインストール不要・登録不要・サーバー送信なしを徹底した日本語向け無料Webツール集。運営者・収録ツール・技術スタック・オープンソース方針について紹介します。">
+    <meta property="og:site_name" content="KIRICAB Tools">
+    <meta property="og:locale" content="ja_JP">
+    <meta property="og:image" content="https://kiricab.github.io/common/og-image.svg">
+    <meta property="og:image:width" content="1200">
+    <meta property="og:image:height" content="630">
+    <!-- Twitter Card -->
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="このサイトについて | KIRICAB Tools">
+    <meta name="twitter:description" content="KIRICAB Toolsはインストール不要・登録不要・サーバー送信なしを徹底した日本語向け無料Webツール集。運営者・収録ツール・技術スタック・オープンソース方針について紹介します。">
+    <meta name="twitter:image" content="https://kiricab.github.io/common/og-image.svg">
+    <!-- Canonical -->
+    <link rel="canonical" href="https://kiricab.github.io/about/">
+
+    <link rel="icon" href="../common/favicon.svg">
+    <link rel="preconnect" href="https://www.googletagmanager.com">
+    <link rel="preconnect" href="https://pagead2.googlesyndication.com">
+    <link rel="stylesheet" href="../common/style.css">
+
+    <style>
+        .tool-list {
+            list-style: none;
+            padding: 0;
+            margin: 1rem 0;
+        }
+        .tool-list li {
+            padding: 0.6rem 0;
+            border-bottom: 1px dashed var(--secondary-color);
+        }
+        .tool-list li:last-child {
+            border-bottom: none;
+        }
+        .tool-list a {
+            font-weight: 600;
+            color: var(--primary-color);
+        }
+        .tool-list .tool-list-desc {
+            display: block;
+            margin-top: 0.2rem;
+            color: var(--gray-text-color);
+            font-size: 0.9rem;
+        }
+    </style>
+
+    <!-- Google AdSense-->
+    <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8141179596557780"
+     crossorigin="anonymous"></script>
+    <meta name="google-adsense-account" content="ca-pub-8141179596557780">
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-CN3KBWSXRE"></script>
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+        gtag('config', 'G-CN3KBWSXRE');
+    </script>
+</head>
+<body>
+
+    <header>
+        <div class="container">
+            <h1>このサイトについて</h1>
+            <p>KIRICAB Toolsのミッション・運営者・収録ツール</p>
+        </div>
+    </header>
+
+    <main>
+        <div class="container">
+            <section class="seo-content">
+                <h2>KIRICAB Tools とは</h2>
+                <p>KIRICAB Tools は、日々のデジタル作業をブラウザだけで完結させる<strong>無料の Web ツール集</strong>です。パスワード生成・Slack カスタム絵文字作成・テキスト比較・カラーパレット作成・QR コード生成・印鑑作成・あみだくじ・写真のフィルム調フィルター・Markdown カンバンといった、ちょっとした作業を素早く片付けるための道具を 1 つのドメインに集めています。</p>
+
+                <h2>設計の3つの哲学</h2>
+                <ul>
+                    <li><strong>プライバシーファースト</strong>: 入力データはお使いのブラウザ内で処理し、運営者や第三者のサーバへ送信しません。社内文書・個人情報を含む素材でも安心して扱えるようにしています。</li>
+                    <li><strong>登録・インストール不要</strong>: アカウント作成は不要で、ページを開いた瞬間から全機能をお使いいただけます。アプリのインストールも不要、PC でもスマートフォンでも同じ操作感です。</li>
+                    <li><strong>軽量・無料</strong>: 小さなツール 1 つあたり 1 ページで完結します。読み込みは速く、すべて無料でご利用いただけます。運営費用は本サイト上の広告（Google AdSense）でまかなっています。</li>
+                </ul>
+
+                <h2>運営者について</h2>
+                <p>本サイトはハンドル名「<strong>Kiricab</strong>」が個人で運営しています。GitHub プロフィール: <a href="https://github.com/kiricab" rel="noopener" target="_blank">https://github.com/kiricab</a>。バグ報告や機能要望は <a href="../contact/index.html">お問い合わせページ</a> 経由でいつでも歓迎します。</p>
+
+                <h2>収録ツール一覧</h2>
+                <ul class="tool-list">
+                    <li>
+                        <a href="../passgen/index.html">🔐 パスワード生成</a>
+                        <span class="tool-list-desc">文字種・桁数・生成数を指定して、安全でランダムなパスワードを一括生成。Web Crypto API ベースで暗号学的に安全。</span>
+                    </li>
+                    <li>
+                        <a href="../slackemojigen/index.html">✏️ Slack 絵文字生成</a>
+                        <span class="tool-list-desc">テキスト・フォント・色を指定して Slack 用カスタム絵文字を作成。Canvas API と Google Fonts によりブラウザだけで完結。</span>
+                    </li>
+                    <li>
+                        <a href="../diff/index.html">🔍 テキスト比較（Diff）</a>
+                        <span class="tool-list-desc">2 つのテキストをサイドバイサイドで比較し、追加・削除箇所を色分けで可視化。文章レビューやコードレビューに。</span>
+                    </li>
+                    <li>
+                        <a href="../colorpallet/index.html">🎨 カラーパレット生成</a>
+                        <span class="tool-list-desc">調和モード（類似色・補色・三角配色・モノクロ）から自動で配色を提案。ロック・保存・PNG / JSON エクスポートに対応。</span>
+                    </li>
+                    <li>
+                        <a href="../qrgen/index.html">📱 QR コード生成</a>
+                        <span class="tool-list-desc">URL・名刺・Wi-Fi など 6 タイプの QR コードに対応。デザインカスタマイズ・ロゴ埋め込み・PNG / SVG ダウンロード対応。</span>
+                    </li>
+                    <li>
+                        <a href="../sealgen/index.html">🖊️ 印鑑ジェネレーター</a>
+                        <span class="tool-list-desc">名前を入力するだけで丸印・角印の印影画像を作成。色・書体・傾きを自由に設定して透過 PNG でダウンロード。</span>
+                    </li>
+                    <li>
+                        <a href="../amida/index.html">🎯 あみだくじ</a>
+                        <span class="tool-list-desc">参加者名と結果を入力するだけで公平なあみだくじを SVG アニメーションで生成。順番決め・ランダム抽選に。</span>
+                    </li>
+                    <li>
+                        <a href="../filmfilter/index.html">🎞️ フィルム風フィルター</a>
+                        <span class="tool-list-desc">アップロードした写真にフィルム調のレトロな質感を付与。15 種のプリセットと細かな微調整に対応。</span>
+                    </li>
+                    <li>
+                        <a href="../mdkanban/index.html">📋 mdカンバン（Markdown ビューワー）</a>
+                        <span class="tool-list-desc">Obsidian Kanban 互換の Markdown を開くだけでカンバン表示。ドラッグ&ドロップで列の並び替え・書き戻しに対応。</span>
+                    </li>
+                </ul>
+
+                <h2>技術スタック</h2>
+                <p>本サイトのすべてのツールは、HTML / CSS / JavaScript の純粋な静的サイトとして実装されています。バックエンド・データベース・ビルドシステムを使わず、<a href="https://pages.github.com/" rel="noopener" target="_blank">GitHub Pages</a> でホスティングしています。アクセス解析に Google Analytics、運営費用のために Google AdSense を利用しています（詳細は <a href="../privacy/index.html">プライバシーポリシー</a> を参照）。</p>
+
+                <h2>オープンソース</h2>
+                <p>本サイトのすべてのソースコードは <a href="https://github.com/kiricab/kiricab.github.io" rel="noopener" target="_blank">GitHub リポジトリ kiricab/kiricab.github.io</a> で公開しています。利用している外部ライブラリは、すべて無償かつ商用利用可能なオープンソースライセンス（MIT・Apache 2.0・BSD・ISC・CC0・OFL 等）に基づいています。コードの再利用・改変・再配布に関する詳細は <a href="../terms/index.html">利用規約</a> をご確認ください。</p>
+
+                <h2>お問い合わせ</h2>
+                <p>不具合のご報告・機能のご要望・運営方針に関するご質問は、<a href="../contact/index.html">お問い合わせページ</a>からお気軽にご連絡ください。</p>
+            </section>
+        </div>
+    </main>
+
+    <footer>
+        <div class="container">
+            <div class="footer-links">
+                <a href="../index.html">ホーム</a>
+                <a href="../passgen/index.html">パスワード生成</a>
+                <a href="../slackemojigen/index.html">Slack絵文字生成</a>
+                <a href="../diff/index.html">テキスト比較</a>
+                <a href="../colorpallet/index.html">カラーパレット生成</a>
+                <a href="../qrgen/index.html">QRコード生成</a>
+                <a href="../sealgen/index.html">印鑑生成</a>
+                <a href="../amida/index.html">あみだくじ</a>
+                <a href="../filmfilter/index.html">フィルム風フィルター</a>
+                <a href="../mdkanban/index.html">mdカンバン</a>
+            </div>
+            <div class="footer-links">
+                <a href="../about/index.html">このサイトについて</a>
+                <a href="../privacy/index.html">プライバシーポリシー</a>
+                <a href="../terms/index.html">利用規約</a>
+                <a href="../contact/index.html">お問い合わせ</a>
+            </div>
+            <p>&copy; 2025 Kiricab. All Rights Reserved.</p>
+        </div>
+    </footer>
+
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "AboutPage",
+      "name": "このサイトについて | KIRICAB Tools",
+      "url": "https://kiricab.github.io/about/",
+      "description": "KIRICAB Toolsはインストール不要・登録不要・サーバー送信なしを徹底した日本語向け無料Webツール集。運営者・収録ツール・技術スタック・オープンソース方針について紹介します。",
+      "inLanguage": "ja",
+      "isPartOf": {
+        "@type": "WebSite",
+        "name": "KIRICAB Tools",
+        "url": "https://kiricab.github.io/"
+      },
+      "mainEntity": {
+        "@type": "Organization",
+        "name": "KIRICAB",
+        "alternateName": "KIRICAB Tools",
+        "url": "https://kiricab.github.io/",
+        "logo": {
+          "@type": "ImageObject",
+          "url": "https://kiricab.github.io/common/og-image.svg",
+          "width": 1200,
+          "height": 630
+        },
+        "founder": {
+          "@type": "Person",
+          "name": "Kiricab",
+          "url": "https://github.com/kiricab"
+        },
+        "sameAs": [
+          "https://github.com/kiricab",
+          "https://github.com/kiricab/kiricab.github.io"
+        ],
+        "contactPoint": {
+          "@type": "ContactPoint",
+          "contactType": "customer support",
+          "url": "https://github.com/kiricab/kiricab.github.io/issues",
+          "availableLanguage": ["Japanese"]
+        }
+      }
+    }
+    </script>
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "BreadcrumbList",
+      "itemListElement": [
+        { "@type": "ListItem", "position": 1, "name": "ホーム", "item": "https://kiricab.github.io/" },
+        { "@type": "ListItem", "position": 2, "name": "このサイトについて", "item": "https://kiricab.github.io/about/" }
+      ]
+    }
+    </script>
+
+</body>
+</html>

--- a/ads.txt
+++ b/ads.txt
@@ -1,0 +1,1 @@
+google.com, pub-8141179596557780, DIRECT, f08c47fec0942fa0

--- a/amida/index.html
+++ b/amida/index.html
@@ -154,6 +154,12 @@
                 <a href="../filmfilter/index.html">フィルム風フィルター</a>
                 <a href="../mdkanban/index.html">mdカンバン</a>
             </div>
+            <div class="footer-links">
+                <a href="../about/index.html">このサイトについて</a>
+                <a href="../privacy/index.html">プライバシーポリシー</a>
+                <a href="../terms/index.html">利用規約</a>
+                <a href="../contact/index.html">お問い合わせ</a>
+            </div>
             <p>&copy; 2025 Kiricab. All Rights Reserved.</p>
         </div>
     </footer>

--- a/colorpallet/index.html
+++ b/colorpallet/index.html
@@ -199,6 +199,12 @@
                 <a href="../filmfilter/index.html">フィルム風フィルター</a>
                 <a href="../mdkanban/index.html">mdカンバン</a>
             </div>
+            <div class="footer-links">
+                <a href="../about/index.html">このサイトについて</a>
+                <a href="../privacy/index.html">プライバシーポリシー</a>
+                <a href="../terms/index.html">利用規約</a>
+                <a href="../contact/index.html">お問い合わせ</a>
+            </div>
             <p>&copy; 2025 Kiricab. All Rights Reserved.</p>
         </div>
     </footer>

--- a/contact/index.html
+++ b/contact/index.html
@@ -1,0 +1,171 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>お問い合わせ | KIRICAB Tools</title>
+    <meta name="description" content="KIRICAB Toolsへのお問い合わせはGitHub Issuesから受け付けています。バグ報告・機能要望・プライバシーや規約に関するご質問にご利用ください。">
+
+    <!-- OGP -->
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="https://kiricab.github.io/contact/">
+    <meta property="og:title" content="お問い合わせ | KIRICAB Tools">
+    <meta property="og:description" content="KIRICAB Toolsへのお問い合わせはGitHub Issuesから受け付けています。バグ報告・機能要望・プライバシーや規約に関するご質問にご利用ください。">
+    <meta property="og:site_name" content="KIRICAB Tools">
+    <meta property="og:locale" content="ja_JP">
+    <meta property="og:image" content="https://kiricab.github.io/common/og-image.svg">
+    <meta property="og:image:width" content="1200">
+    <meta property="og:image:height" content="630">
+    <!-- Twitter Card -->
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="お問い合わせ | KIRICAB Tools">
+    <meta name="twitter:description" content="KIRICAB Toolsへのお問い合わせはGitHub Issuesから受け付けています。バグ報告・機能要望・プライバシーや規約に関するご質問にご利用ください。">
+    <meta name="twitter:image" content="https://kiricab.github.io/common/og-image.svg">
+    <!-- Canonical -->
+    <link rel="canonical" href="https://kiricab.github.io/contact/">
+
+    <link rel="icon" href="../common/favicon.svg">
+    <link rel="preconnect" href="https://www.googletagmanager.com">
+    <link rel="preconnect" href="https://pagead2.googlesyndication.com">
+    <link rel="stylesheet" href="../common/style.css">
+
+    <style>
+        .contact-cta {
+            text-align: center;
+            margin: 2rem 0;
+        }
+        .contact-button {
+            display: inline-flex;
+            align-items: center;
+            gap: 0.6rem;
+            padding: 0.85rem 1.6rem;
+            background-color: var(--primary-color);
+            color: var(--text-color-light);
+            border-radius: var(--border-radius);
+            text-decoration: none;
+            font-weight: 600;
+            font-size: 1rem;
+            transition: background-color 0.2s ease, transform 0.2s ease;
+        }
+        .contact-button:hover {
+            background-color: var(--primary-color-dark);
+            transform: translateY(-2px);
+        }
+    </style>
+
+    <!-- Google AdSense-->
+    <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8141179596557780"
+     crossorigin="anonymous"></script>
+    <meta name="google-adsense-account" content="ca-pub-8141179596557780">
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-CN3KBWSXRE"></script>
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+        gtag('config', 'G-CN3KBWSXRE');
+    </script>
+</head>
+<body>
+
+    <header>
+        <div class="container">
+            <h1>お問い合わせ</h1>
+            <p>バグ報告・機能要望・規約に関するご質問はこちらから</p>
+        </div>
+    </header>
+
+    <main>
+        <div class="container">
+            <section class="seo-content">
+                <h2>連絡方法</h2>
+                <p>KIRICAB Tools へのお問い合わせは、GitHub Issues に一本化しています。下記のボタンから新規 Issue を開いてご連絡ください。GitHub アカウントをお持ちでない場合は、無料で作成いただけます。</p>
+
+                <div class="contact-cta">
+                    <a class="contact-button" href="https://github.com/kiricab/kiricab.github.io/issues" rel="noopener" target="_blank">📮 GitHub Issues を開く</a>
+                </div>
+
+                <h2>受け付けている問い合わせ内容</h2>
+                <ul>
+                    <li>各ツールの不具合報告（ブラウザ・OS・再現手順を添えていただけると解決が早まります）</li>
+                    <li>機能の追加要望・改善提案</li>
+                    <li><a href="../privacy/index.html">プライバシーポリシー</a>・<a href="../terms/index.html">利用規約</a>に関する質問</li>
+                    <li>本サイトの誤字・リンク切れの指摘</li>
+                </ul>
+
+                <h2>応答時間について</h2>
+                <p>本サイトは個人運営のため、お問い合わせへの応答はベストエフォートで行っています。通常は平日 24〜72 時間以内に確認のリアクションを返しますが、応答時間を保証するものではありません。緊急性の高い案件（業務利用での重大なバグ等）も、可能な範囲での対応となる旨ご了承ください。</p>
+
+                <h2>個人情報の取り扱い</h2>
+                <p>GitHub Issues は公開掲示板の性質を持つため、投稿内容は公開されます。個人情報（実名・住所・電話番号・メールアドレス等）は記載しないでください。記載が必要な場合は、可能な限り抽象化または伏字でのご投稿をお願いします。本サイトの運営者は、Issue 投稿に含まれる情報を <a href="../privacy/index.html">プライバシーポリシー</a> の範囲で取り扱います。</p>
+            </section>
+        </div>
+    </main>
+
+    <footer>
+        <div class="container">
+            <div class="footer-links">
+                <a href="../index.html">ホーム</a>
+                <a href="../passgen/index.html">パスワード生成</a>
+                <a href="../slackemojigen/index.html">Slack絵文字生成</a>
+                <a href="../diff/index.html">テキスト比較</a>
+                <a href="../colorpallet/index.html">カラーパレット生成</a>
+                <a href="../qrgen/index.html">QRコード生成</a>
+                <a href="../sealgen/index.html">印鑑生成</a>
+                <a href="../amida/index.html">あみだくじ</a>
+                <a href="../filmfilter/index.html">フィルム風フィルター</a>
+                <a href="../mdkanban/index.html">mdカンバン</a>
+            </div>
+            <div class="footer-links">
+                <a href="../about/index.html">このサイトについて</a>
+                <a href="../privacy/index.html">プライバシーポリシー</a>
+                <a href="../terms/index.html">利用規約</a>
+                <a href="../contact/index.html">お問い合わせ</a>
+            </div>
+            <p>&copy; 2025 Kiricab. All Rights Reserved.</p>
+        </div>
+    </footer>
+
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "ContactPage",
+      "name": "お問い合わせ | KIRICAB Tools",
+      "url": "https://kiricab.github.io/contact/",
+      "description": "KIRICAB Toolsへのお問い合わせはGitHub Issuesから受け付けています。バグ報告・機能要望・プライバシーや規約に関するご質問にご利用ください。",
+      "inLanguage": "ja",
+      "isPartOf": {
+        "@type": "WebSite",
+        "name": "KIRICAB Tools",
+        "url": "https://kiricab.github.io/"
+      },
+      "publisher": {
+        "@type": "Organization",
+        "name": "KIRICAB",
+        "url": "https://kiricab.github.io/",
+        "logo": {
+          "@type": "ImageObject",
+          "url": "https://kiricab.github.io/common/favicon.svg"
+        },
+        "contactPoint": {
+          "@type": "ContactPoint",
+          "contactType": "customer support",
+          "url": "https://github.com/kiricab/kiricab.github.io/issues",
+          "availableLanguage": ["Japanese"]
+        }
+      }
+    }
+    </script>
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "BreadcrumbList",
+      "itemListElement": [
+        { "@type": "ListItem", "position": 1, "name": "ホーム", "item": "https://kiricab.github.io/" },
+        { "@type": "ListItem", "position": 2, "name": "お問い合わせ", "item": "https://kiricab.github.io/contact/" }
+      ]
+    }
+    </script>
+
+</body>
+</html>

--- a/diff/index.html
+++ b/diff/index.html
@@ -114,6 +114,12 @@
                 <a href="../filmfilter/index.html">フィルム風フィルター</a>
                 <a href="../mdkanban/index.html">mdカンバン</a>
             </div>
+            <div class="footer-links">
+                <a href="../about/index.html">このサイトについて</a>
+                <a href="../privacy/index.html">プライバシーポリシー</a>
+                <a href="../terms/index.html">利用規約</a>
+                <a href="../contact/index.html">お問い合わせ</a>
+            </div>
             <p>&copy; 2025 Kiricab. All Rights Reserved.</p>
         </div>
     </footer>

--- a/filmfilter/index.html
+++ b/filmfilter/index.html
@@ -250,6 +250,12 @@
                 <a href="../filmfilter/index.html">フィルム風フィルター</a>
                 <a href="../mdkanban/index.html">mdカンバン</a>
             </div>
+            <div class="footer-links">
+                <a href="../about/index.html">このサイトについて</a>
+                <a href="../privacy/index.html">プライバシーポリシー</a>
+                <a href="../terms/index.html">利用規約</a>
+                <a href="../contact/index.html">お問い合わせ</a>
+            </div>
             <p>&copy; 2025 Kiricab. All Rights Reserved.</p>
         </div>
     </footer>

--- a/index.html
+++ b/index.html
@@ -273,6 +273,12 @@
             <a href="./filmfilter/index.html">フィルム風フィルター</a>
             <a href="./mdkanban/index.html">mdカンバン</a>
         </div>
+            <div class="footer-links">
+                <a href="./about/index.html">このサイトについて</a>
+                <a href="./privacy/index.html">プライバシーポリシー</a>
+                <a href="./terms/index.html">利用規約</a>
+                <a href="./contact/index.html">お問い合わせ</a>
+            </div>
         <p>&copy; 2025 Kiricab. All Rights Reserved.</p>
     </footer>
 

--- a/mdkanban/index.html
+++ b/mdkanban/index.html
@@ -376,6 +376,12 @@
         <a href="../filmfilter/index.html">フィルム風フィルター</a>
         <a href="../mdkanban/index.html">mdカンバン</a>
       </div>
+            <div class="footer-links">
+                <a href="../about/index.html">このサイトについて</a>
+                <a href="../privacy/index.html">プライバシーポリシー</a>
+                <a href="../terms/index.html">利用規約</a>
+                <a href="../contact/index.html">お問い合わせ</a>
+            </div>
       <p>&copy; 2025 Kiricab. All Rights Reserved.</p>
     </div>
   </footer>

--- a/passgen/index.html
+++ b/passgen/index.html
@@ -149,6 +149,12 @@
                 <a href="../filmfilter/index.html">フィルム風フィルター</a>
                 <a href="../mdkanban/index.html">mdカンバン</a>
             </div>
+            <div class="footer-links">
+                <a href="../about/index.html">このサイトについて</a>
+                <a href="../privacy/index.html">プライバシーポリシー</a>
+                <a href="../terms/index.html">利用規約</a>
+                <a href="../contact/index.html">お問い合わせ</a>
+            </div>
             <p>&copy; 2025 Kiricab. All Rights Reserved.</p>
         </div>
     </footer>

--- a/privacy/index.html
+++ b/privacy/index.html
@@ -1,0 +1,148 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>プライバシーポリシー | KIRICAB Tools</title>
+    <meta name="description" content="KIRICAB Toolsのプライバシーポリシー。すべての処理はブラウザ内で完結しサーバには送信されません。Google Analytics・Google AdSenseの利用状況とオプトアウト方法を明記しています。">
+
+    <!-- OGP -->
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="https://kiricab.github.io/privacy/">
+    <meta property="og:title" content="プライバシーポリシー | KIRICAB Tools">
+    <meta property="og:description" content="KIRICAB Toolsのプライバシーポリシー。すべての処理はブラウザ内で完結しサーバには送信されません。Google Analytics・Google AdSenseの利用状況とオプトアウト方法を明記しています。">
+    <meta property="og:site_name" content="KIRICAB Tools">
+    <meta property="og:locale" content="ja_JP">
+    <meta property="og:image" content="https://kiricab.github.io/common/og-image.svg">
+    <meta property="og:image:width" content="1200">
+    <meta property="og:image:height" content="630">
+    <!-- Twitter Card -->
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="プライバシーポリシー | KIRICAB Tools">
+    <meta name="twitter:description" content="KIRICAB Toolsのプライバシーポリシー。すべての処理はブラウザ内で完結しサーバには送信されません。Google Analytics・Google AdSenseの利用状況とオプトアウト方法を明記しています。">
+    <meta name="twitter:image" content="https://kiricab.github.io/common/og-image.svg">
+    <!-- Canonical -->
+    <link rel="canonical" href="https://kiricab.github.io/privacy/">
+
+    <link rel="icon" href="../common/favicon.svg">
+    <link rel="preconnect" href="https://www.googletagmanager.com">
+    <link rel="preconnect" href="https://pagead2.googlesyndication.com">
+    <link rel="stylesheet" href="../common/style.css">
+
+    <!-- Google AdSense-->
+    <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8141179596557780"
+     crossorigin="anonymous"></script>
+    <meta name="google-adsense-account" content="ca-pub-8141179596557780">
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-CN3KBWSXRE"></script>
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+        gtag('config', 'G-CN3KBWSXRE');
+    </script>
+</head>
+<body>
+
+    <header>
+        <div class="container">
+            <h1>プライバシーポリシー</h1>
+            <p>KIRICAB Toolsにおける情報の取り扱いについて</p>
+        </div>
+    </header>
+
+    <main>
+        <div class="container">
+            <section class="seo-content">
+                <h2>1. ポリシーの目的と適用範囲</h2>
+                <p>本プライバシーポリシー（以下「本ポリシー」）は、Kiricab（以下「運営者」）が運営する <a href="../index.html">KIRICAB Tools</a>（<code>https://kiricab.github.io/</code> 配下のすべてのページ・ツールを含む。以下「本サイト」）の利用に伴う情報の取り扱い方針を定めるものです。本サイトを利用される前に、本ポリシーをご一読ください。</p>
+
+                <h2>2. 本サイトが収集する情報</h2>
+                <p>本サイト上の各ツール（パスワード生成、Slack絵文字生成、テキスト比較、カラーパレット生成、QRコード生成、印鑑生成、あみだくじ、フィルム風フィルター、mdカンバン）は<strong>すべての処理をお使いのブラウザ内で完結</strong>させる設計です。入力されたパスワード・テキスト・画像・Markdownファイル等の情報を、運営者のサーバまたは第三者のサーバへ送信することはありません。</p>
+                <p>一部のツールは、操作の継続性を確保するためにブラウザの <code>localStorage</code> および <code>IndexedDB</code> を使用します（例: カラーパレットの保存履歴、mdカンバンの直近のファイル内容、ダークモード等の設定）。これらのデータは<strong>お使いのブラウザ内にのみ保存</strong>され、運営者を含む外部から閲覧することはできません。ブラウザの履歴やストレージを削除すれば消去できます。</p>
+
+                <h2>3. Google Analytics の利用</h2>
+                <p>本サイトでは、アクセス状況の把握と品質向上のため、Google LLC が提供する解析ツール「Google Analytics」（測定 ID: <code>G-CN3KBWSXRE</code>）を利用しています。Google Analytics はクッキー（Cookie）を用いて訪問データを収集しますが、収集されるデータには個人を特定する情報は含まれず、Google のサーバへ匿名化された形で送信されます。</p>
+                <p>Google Analytics による情報収集を停止したい場合は、Google が提供する <a href="https://tools.google.com/dlpage/gaoptout?hl=ja" rel="noopener" target="_blank">Google アナリティクス オプトアウト アドオン</a>をご利用いただくか、ブラウザのクッキーを無効化してください。Google によるデータ取り扱いの詳細は <a href="https://policies.google.com/privacy?hl=ja" rel="noopener" target="_blank">Google プライバシーポリシー</a> をご確認ください。</p>
+
+                <h2>4. Google AdSense の利用</h2>
+                <p>本サイトでは、運営費用に充てるための第三者配信広告サービスとして、Google LLC が提供する「Google AdSense」（パブリッシャー ID: <code>ca-pub-8141179596557780</code>）を利用しています。Google AdSense はクッキーを用いて、ユーザーが過去に本サイトおよび他のサイトに訪問した情報をもとに、興味関心に応じた広告を表示する場合があります。</p>
+                <p>パーソナライズド広告を無効にしたい場合は、<a href="https://www.google.com/settings/ads" rel="noopener" target="_blank">Google 広告設定</a>から個別にオプトアウトできます。第三者ベンダーによる広告配信については <a href="https://policies.google.com/technologies/partner-sites?hl=ja" rel="noopener" target="_blank">パートナー サイトでの Google のサービス利用について</a> および <a href="https://policies.google.com/technologies/ads?hl=ja" rel="noopener" target="_blank">広告に関する Google のポリシー</a> をご確認ください。</p>
+
+                <h2>5. 第三者への情報提供</h2>
+                <p>運営者は、上記 3. および 4. で述べた Google LLC が提供するサービス（Google Analytics・Google AdSense）以外に、本サイトの利用状況に関する情報を第三者へ提供することはありません。法令に基づく開示請求がある場合のみ、必要な範囲で対応します。</p>
+
+                <h2>6. お問い合わせ</h2>
+                <p>本ポリシーに関するご質問・ご指摘は、<a href="../contact/index.html">お問い合わせページ</a>から GitHub Issues 経由でご連絡ください。</p>
+
+                <h2>7. 本ポリシーの改定</h2>
+                <p>運営者は、法令の変更・利用状況の変化に応じて、本ポリシーを予告なく変更することがあります。重要な変更がある場合は、本ページの「制定日」欄を更新してお知らせします。本サイトの利用を継続される場合、改定後のポリシーに同意したものとみなします。</p>
+
+                <h2>8. 制定日</h2>
+                <p>2026年5月20日 制定</p>
+            </section>
+        </div>
+    </main>
+
+    <footer>
+        <div class="container">
+            <div class="footer-links">
+                <a href="../index.html">ホーム</a>
+                <a href="../passgen/index.html">パスワード生成</a>
+                <a href="../slackemojigen/index.html">Slack絵文字生成</a>
+                <a href="../diff/index.html">テキスト比較</a>
+                <a href="../colorpallet/index.html">カラーパレット生成</a>
+                <a href="../qrgen/index.html">QRコード生成</a>
+                <a href="../sealgen/index.html">印鑑生成</a>
+                <a href="../amida/index.html">あみだくじ</a>
+                <a href="../filmfilter/index.html">フィルム風フィルター</a>
+                <a href="../mdkanban/index.html">mdカンバン</a>
+            </div>
+            <div class="footer-links">
+                <a href="../about/index.html">このサイトについて</a>
+                <a href="../privacy/index.html">プライバシーポリシー</a>
+                <a href="../terms/index.html">利用規約</a>
+                <a href="../contact/index.html">お問い合わせ</a>
+            </div>
+            <p>&copy; 2025 Kiricab. All Rights Reserved.</p>
+        </div>
+    </footer>
+
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "WebPage",
+      "name": "プライバシーポリシー",
+      "url": "https://kiricab.github.io/privacy/",
+      "description": "KIRICAB Toolsのプライバシーポリシー。すべての処理はブラウザ内で完結しサーバには送信されません。Google Analytics・Google AdSenseの利用状況とオプトアウト方法を明記しています。",
+      "inLanguage": "ja",
+      "isPartOf": {
+        "@type": "WebSite",
+        "name": "KIRICAB Tools",
+        "url": "https://kiricab.github.io/"
+      },
+      "publisher": {
+        "@type": "Organization",
+        "name": "KIRICAB",
+        "url": "https://kiricab.github.io/",
+        "logo": {
+          "@type": "ImageObject",
+          "url": "https://kiricab.github.io/common/favicon.svg"
+        }
+      },
+      "dateModified": "2026-05-20"
+    }
+    </script>
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "BreadcrumbList",
+      "itemListElement": [
+        { "@type": "ListItem", "position": 1, "name": "ホーム", "item": "https://kiricab.github.io/" },
+        { "@type": "ListItem", "position": 2, "name": "プライバシーポリシー", "item": "https://kiricab.github.io/privacy/" }
+      ]
+    }
+    </script>
+
+</body>
+</html>

--- a/qrgen/index.html
+++ b/qrgen/index.html
@@ -402,6 +402,12 @@
         <a href="../filmfilter/index.html">フィルム風フィルター</a>
         <a href="../mdkanban/index.html">mdカンバン</a>
       </div>
+            <div class="footer-links">
+                <a href="../about/index.html">このサイトについて</a>
+                <a href="../privacy/index.html">プライバシーポリシー</a>
+                <a href="../terms/index.html">利用規約</a>
+                <a href="../contact/index.html">お問い合わせ</a>
+            </div>
       <p>&copy; 2025 Kiricab. All Rights Reserved.</p>
     </div>
   </footer>

--- a/sealgen/index.html
+++ b/sealgen/index.html
@@ -264,6 +264,12 @@
                 <a href="../filmfilter/index.html">フィルム風フィルター</a>
                 <a href="../mdkanban/index.html">mdカンバン</a>
             </div>
+            <div class="footer-links">
+                <a href="../about/index.html">このサイトについて</a>
+                <a href="../privacy/index.html">プライバシーポリシー</a>
+                <a href="../terms/index.html">利用規約</a>
+                <a href="../contact/index.html">お問い合わせ</a>
+            </div>
             <p>&copy; 2025 Kiricab. All Rights Reserved.</p>
         </div>
     </footer>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -56,8 +56,32 @@
   </url>
   <url>
     <loc>https://kiricab.github.io/mdkanban/</loc>
-    <lastmod>2026-05-09</lastmod>
+    <lastmod>2026-05-20</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.80</priority>
+  </url>
+  <url>
+    <loc>https://kiricab.github.io/about/</loc>
+    <lastmod>2026-05-20</lastmod>
+    <changefreq>yearly</changefreq>
+    <priority>0.50</priority>
+  </url>
+  <url>
+    <loc>https://kiricab.github.io/privacy/</loc>
+    <lastmod>2026-05-20</lastmod>
+    <changefreq>yearly</changefreq>
+    <priority>0.30</priority>
+  </url>
+  <url>
+    <loc>https://kiricab.github.io/terms/</loc>
+    <lastmod>2026-05-20</lastmod>
+    <changefreq>yearly</changefreq>
+    <priority>0.30</priority>
+  </url>
+  <url>
+    <loc>https://kiricab.github.io/contact/</loc>
+    <lastmod>2026-05-20</lastmod>
+    <changefreq>yearly</changefreq>
+    <priority>0.50</priority>
   </url>
 </urlset>

--- a/slackemojigen/index.html
+++ b/slackemojigen/index.html
@@ -141,6 +141,12 @@
                 <a href="../filmfilter/index.html">フィルム風フィルター</a>
                 <a href="../mdkanban/index.html">mdカンバン</a>
             </div>
+            <div class="footer-links">
+                <a href="../about/index.html">このサイトについて</a>
+                <a href="../privacy/index.html">プライバシーポリシー</a>
+                <a href="../terms/index.html">利用規約</a>
+                <a href="../contact/index.html">お問い合わせ</a>
+            </div>
             <p>&copy; 2025 Kiricab. All Rights Reserved.</p>
         </div>
     </footer>

--- a/terms/index.html
+++ b/terms/index.html
@@ -1,0 +1,163 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>利用規約 | KIRICAB Tools</title>
+    <meta name="description" content="KIRICAB Toolsの利用規約。本サイトの各ツールを利用される際の条件・免責事項・禁止事項・知的財産権・準拠法について定めています。">
+
+    <!-- OGP -->
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="https://kiricab.github.io/terms/">
+    <meta property="og:title" content="利用規約 | KIRICAB Tools">
+    <meta property="og:description" content="KIRICAB Toolsの利用規約。本サイトの各ツールを利用される際の条件・免責事項・禁止事項・知的財産権・準拠法について定めています。">
+    <meta property="og:site_name" content="KIRICAB Tools">
+    <meta property="og:locale" content="ja_JP">
+    <meta property="og:image" content="https://kiricab.github.io/common/og-image.svg">
+    <meta property="og:image:width" content="1200">
+    <meta property="og:image:height" content="630">
+    <!-- Twitter Card -->
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="利用規約 | KIRICAB Tools">
+    <meta name="twitter:description" content="KIRICAB Toolsの利用規約。本サイトの各ツールを利用される際の条件・免責事項・禁止事項・知的財産権・準拠法について定めています。">
+    <meta name="twitter:image" content="https://kiricab.github.io/common/og-image.svg">
+    <!-- Canonical -->
+    <link rel="canonical" href="https://kiricab.github.io/terms/">
+
+    <link rel="icon" href="../common/favicon.svg">
+    <link rel="preconnect" href="https://www.googletagmanager.com">
+    <link rel="preconnect" href="https://pagead2.googlesyndication.com">
+    <link rel="stylesheet" href="../common/style.css">
+
+    <!-- Google AdSense-->
+    <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8141179596557780"
+     crossorigin="anonymous"></script>
+    <meta name="google-adsense-account" content="ca-pub-8141179596557780">
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-CN3KBWSXRE"></script>
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+        gtag('config', 'G-CN3KBWSXRE');
+    </script>
+</head>
+<body>
+
+    <header>
+        <div class="container">
+            <h1>利用規約</h1>
+            <p>KIRICAB Toolsをご利用いただく前に</p>
+        </div>
+    </header>
+
+    <main>
+        <div class="container">
+            <section class="seo-content">
+                <h2>第1条 (目的)</h2>
+                <p>本利用規約（以下「本規約」）は、Kiricab（以下「運営者」）が提供する <a href="../index.html">KIRICAB Tools</a>（<code>https://kiricab.github.io/</code> 配下のすべてのページ・ツールを含む。以下「本サイト」）の利用条件を定めるものです。本サイトを利用された時点で、利用者は本規約に同意したものとみなします。</p>
+
+                <h2>第2条 (利用条件)</h2>
+                <p>本サイトの各ツールは、登録・ログイン不要で無料でご利用いただけます。日本国内外を問わず、本規約に同意できる方であればどなたでも利用できます。利用にあたって個別の契約を締結する必要はありません。</p>
+
+                <h2>第3条 (免責事項)</h2>
+                <p>本サイトの各ツールは、現状有姿で提供されます。運営者は以下の事項について、明示・黙示を問わず一切の保証を行いません。</p>
+                <ul>
+                    <li>ツールの動作の正確性・完全性・最新性・特定目的への適合性</li>
+                    <li>生成された出力（パスワード・QRコード・印刷物・カラーパレット・印鑑画像・Markdownファイル等）の品質・安全性・適法性</li>
+                    <li>本サイトの利用または利用不能によって利用者に生じる損害（データの消失、機会損失、第三者からの請求等を含む）</li>
+                    <li>ブラウザ・端末・OS の組み合わせによる動作の差異</li>
+                </ul>
+                <p>本サイトの利用は、すべて利用者ご自身の責任において行ってください。生成された出力を業務・公的手続き等で使用する場合は、利用者の責任において結果を検証してください。</p>
+
+                <h2>第4条 (禁止事項)</h2>
+                <p>本サイトの利用にあたって、利用者は以下の行為を行ってはならないものとします。</p>
+                <ul>
+                    <li>法令・公序良俗に違反する行為、または違反するおそれのある行為</li>
+                    <li>本サイトの出力を用いて、他者になりすます行為、詐欺行為、その他第三者の権利を侵害する行為</li>
+                    <li>本サイトのサーバ・配信に過度な負荷を与える自動化アクセス、スクレイピングの大量実行</li>
+                    <li>本サイトの脆弱性を悪意ある目的で探索・利用する行為</li>
+                    <li>その他、運営者が不適切と判断する行為</li>
+                </ul>
+
+                <h2>第5条 (知的財産権)</h2>
+                <p>本サイトのソースコードは GitHub 上の <a href="https://github.com/kiricab/kiricab.github.io" rel="noopener" target="_blank">kiricab/kiricab.github.io</a> リポジトリで公開されています。コードの再利用・改変・再配布は、リポジトリに含まれる該当ライセンス条件に従ってください。</p>
+                <p>各ツールが内部で利用している外部ライブラリは、それぞれ MIT・Apache 2.0・BSD・ISC・CC0・OFL 等の無償かつ商用利用可能なオープンソースライセンスに基づいています。ライブラリの著作権・ライセンス表示は元のライブラリに従います。</p>
+
+                <h2>第6条 (規約の変更)</h2>
+                <p>運営者は、必要と判断した場合に、利用者への事前の通知なく本規約を変更できるものとします。変更後の規約は本ページに掲載された時点から効力を生じるものとし、利用者が本サイトの利用を継続した場合、変更後の規約に同意したものとみなします。</p>
+
+                <h2>第7条 (準拠法・管轄)</h2>
+                <p>本規約の解釈および本サイトの利用に関して生じる紛争については、日本法を準拠法とし、運営者の住所地を管轄する裁判所を第一審の専属的合意管轄裁判所とします。</p>
+
+                <h2>第8条 (お問い合わせ)</h2>
+                <p>本規約に関するご質問・ご指摘は、<a href="../contact/index.html">お問い合わせページ</a>から GitHub Issues 経由でご連絡ください。</p>
+
+                <h2>制定日</h2>
+                <p>2026年5月20日 制定</p>
+            </section>
+        </div>
+    </main>
+
+    <footer>
+        <div class="container">
+            <div class="footer-links">
+                <a href="../index.html">ホーム</a>
+                <a href="../passgen/index.html">パスワード生成</a>
+                <a href="../slackemojigen/index.html">Slack絵文字生成</a>
+                <a href="../diff/index.html">テキスト比較</a>
+                <a href="../colorpallet/index.html">カラーパレット生成</a>
+                <a href="../qrgen/index.html">QRコード生成</a>
+                <a href="../sealgen/index.html">印鑑生成</a>
+                <a href="../amida/index.html">あみだくじ</a>
+                <a href="../filmfilter/index.html">フィルム風フィルター</a>
+                <a href="../mdkanban/index.html">mdカンバン</a>
+            </div>
+            <div class="footer-links">
+                <a href="../about/index.html">このサイトについて</a>
+                <a href="../privacy/index.html">プライバシーポリシー</a>
+                <a href="../terms/index.html">利用規約</a>
+                <a href="../contact/index.html">お問い合わせ</a>
+            </div>
+            <p>&copy; 2025 Kiricab. All Rights Reserved.</p>
+        </div>
+    </footer>
+
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "WebPage",
+      "name": "利用規約",
+      "url": "https://kiricab.github.io/terms/",
+      "description": "KIRICAB Toolsの利用規約。本サイトの各ツールを利用される際の条件・免責事項・禁止事項・知的財産権・準拠法について定めています。",
+      "inLanguage": "ja",
+      "isPartOf": {
+        "@type": "WebSite",
+        "name": "KIRICAB Tools",
+        "url": "https://kiricab.github.io/"
+      },
+      "publisher": {
+        "@type": "Organization",
+        "name": "KIRICAB",
+        "url": "https://kiricab.github.io/",
+        "logo": {
+          "@type": "ImageObject",
+          "url": "https://kiricab.github.io/common/favicon.svg"
+        }
+      },
+      "dateModified": "2026-05-20"
+    }
+    </script>
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "BreadcrumbList",
+      "itemListElement": [
+        { "@type": "ListItem", "position": 1, "name": "ホーム", "item": "https://kiricab.github.io/" },
+        { "@type": "ListItem", "position": 2, "name": "利用規約", "item": "https://kiricab.github.io/terms/" }
+      ]
+    }
+    </script>
+
+</body>
+</html>


### PR DESCRIPTION
Google AdSense 申請でコンテンツ不十分として却下されたのを受け、不足していた
プライバシーポリシー・利用規約・お問い合わせ・このサイトについての4ページを
新設した。各ページは共通スタイルを継承し、JSON-LD（WebPage/ContactPage/
AboutPage + Organization + BreadcrumbList）で構造化データも整備。全11既存 ページのフッターに「サイト情報」セクションを追加し補助ページへ常時導線を確保。

新規:
- privacy/    - プライバシーポリシー（GA/AdSense のクッキー利用とオプトアウト案内）
- terms/      - 利用規約（免責・禁止事項・準拠法 8 条構成）
- contact/    - お問い合わせ（GitHub Issues 一本化、ContactPoint スキーマ付き）
- about/      - このサイトについて（運営者 Kiricab、9 ツール紹介リスト、
                Organization + Person スキーマで AdSense の運営者識別性を強化）
- ads.txt     - google.com, pub-8141179596557780, DIRECT, f08c47fec0942fa0

更新:
- 既存 11 ページ（root/404/9 ツール）のフッターに 4 補助ページへのリンクを追加
- sitemap.xml に 4 ページを追加、mdkanban の lastmod を更新
- CLAUDE.md にリポジトリ構成・フッター構成の説明を追記
- README.md にサイト情報セクションを追記

🤖 Generated with [Claude Code](https://claude.com/claude-code)